### PR TITLE
Showing the username, hostname and the path of the current directory in the terminal prompt name (PS1 variable) while changing directories in the terminal.

### DIFF
--- a/terminal.py
+++ b/terminal.py
@@ -354,6 +354,7 @@ class TerminalActivity(activity.Activity):
 
         # Launch the default shell in the HOME directory.
         os.chdir(os.environ["HOME"])
+        os.environ["PS1"] = "\u@\h:\w\$ "
 
         if tab_state:
             # Restore the environment.


### PR DESCRIPTION
It would be helpful for the user if we show them otherwise it would be difficult for the user figure out where he is in. :)