### PR TITLE
fix terminal not stopping on child exit

### DIFF
--- a/terminal.py
+++ b/terminal.py
@@ -289,7 +289,7 @@ class TerminalActivity(activity.Activity):
         if self._notebook.get_n_pages() == 0:
             self.close()
 
-    def __tab_child_exited_cb(self, vt):
+    def __tab_child_exited_cb(self, vt, status=None):
         for i in range(self._notebook.get_n_pages()):
             if self._notebook.get_nth_page(i).vt == vt:
                 self._close_tab(i)


### PR DESCRIPTION
Ctrl-d or exit in the terminal did not close the window.

```
TypeError: __tab_child_exited_cb() takes exactly 2 arguments (3 given)
```

First seen Ubuntu 15.10, where Vte 2.91 gives a new *status* parameter to the *child-exited* signal.

Older Vte does not give a status parameter;
 - Vte 2.90 on Ubuntu 14.04,
 - Vte 0.34.9 on Fedora 20, nor
 - Vte 0.34.2 on Fedora 18.

Accept an optional status parameter, but ignore it.

(No need for new release, as I'm not blocking on this patch.)